### PR TITLE
Implement hardened _wait_for_image_installed() method

### DIFF
--- a/pyntc/__init__.py
+++ b/pyntc/__init__.py
@@ -11,6 +11,8 @@ try:
 except ImportError:
     from ConfigParser import SafeConfigParser
 
+__version__ = "0.0.9"
+
 LIB_PATH_ENV_VAR = 'PYNTC_CONF'
 LIB_PATH_DEFAULT = '~/.ntc.conf'
 

--- a/pyntc/devices/f5_device.py
+++ b/pyntc/devices/f5_device.py
@@ -354,8 +354,13 @@ class F5Device(BaseDevice):
 
         while time.time() < end_time:
             time.sleep(20)
-            if self.image_installed(image_name=image_name, volume=volume):
-                return
+            # Avoid race-conditions issues. Newly created volumes _might_ lack
+            # of .version attribute in first seconds of their live.
+            try:
+                if self.image_installed(image_name=image_name, volume=volume):
+                    return
+            except:
+                pass
 
         raise OSInstallError(hostname=self.facts.get("hostname"), desired_boot=volume)
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,12 @@
 from setuptools import find_packages, setup
+import re
+
+with open("pyntc/__init__.py") as pkg_init:
+	# Create a dict of all dunder vars and their values in package __init__
+    metadata = dict(re.findall("__(\w+)__\s*=\s*\"(\S+?)\"", pkg_init.read()))
 
 name = 'pyntc'
-version = '0.0.8'
+version = metadata["version"]
 packages = find_packages()
 package_data = {'pyntc': ['templates/*.template', 'devices/tables/jnpr/*.yml']}
 


### PR DESCRIPTION
This resolves potential race-condition issue as ntc-ansible tests showed:

fatal: [localhost -> localhost]: FAILED! => {"changed": false, "msg": "'<class 'f5.bigip.tm.sys.software.volume.Volume'>' object has no attribute 'version'"}

